### PR TITLE
Changing name of ENV used for RubyGems API key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 
@@ -26,4 +27,4 @@ jobs:
           gem build simple_analytics_rails.gemspec
           gem push simple_analytics_rails-*.gem
         env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}
+          GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}


### PR DESCRIPTION
It looked like we named our Secret differently in the repo. So correcting that & re-releasing.