### PR TITLE
feat: Fixing Apprasial Set error by downgrading rake to 13.0.3

### DIFF
--- a/simple_analytics_rails.gemspec
+++ b/simple_analytics_rails.gemspec
@@ -27,7 +27,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "appraisal", "~> 2.4"
   spec.add_development_dependency "rails", ">= 5.2"
-  spec.add_development_dependency "rake", "~> 13.0"
+
+  # TODO: When appraisal releases an update we can unlock this rake version.
+  spec.add_development_dependency "rake", "= 13.0.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-rails", "~> 4.0"
   spec.add_development_dependency "standardrb", "~> 1.0"


### PR DESCRIPTION
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/325384/124939700-f618a780-dfce-11eb-8b3d-06cf5c4bf358.png">


It looks like the latest version of Rake breaks Appraisal, there is a fix ( https://github.com/thoughtbot/appraisal/pull/184 ) PR'ed, but for now we'll just lock the rake version.