### PR TITLE
fix: use the safe navigation for nil responses.

### DIFF
--- a/lib/simple_analytics_rails/middleware/javascript_injection.rb
+++ b/lib/simple_analytics_rails/middleware/javascript_injection.rb
@@ -20,8 +20,8 @@ module SimpleAnalyticsRails::Middleware
 
     def inject_javascript_to_response(response)
       if SimpleAnalyticsRails.configuration.enabled? && response.respond_to?("[]")
-        response[0].gsub!("</head>", "#{javascript_script.head_html}</head>")
-        response[0].gsub!("</body>", "#{javascript_script.body_html}</body>")
+        response[0]&.gsub!("</head>", "#{javascript_script.head_html}</head>")
+        response[0]&.gsub!("</body>", "#{javascript_script.body_html}</body>")
       end
 
       response


### PR DESCRIPTION
- Uses the safe navigation operator in the `response[0]` so that we don't receive an error when attempting to gsub nil responses.

Fixes https://github.com/simpleanalytics/rubyonrails-plugin/issues/13